### PR TITLE
Update neopixel_direct.py

### DIFF
--- a/octoprint_enclosure/neopixel_direct.py
+++ b/octoprint_enclosure/neopixel_direct.py
@@ -1,4 +1,4 @@
-from neopixel import *
+from rpi_ws281x import *
 import sys
 import time
 


### PR DESCRIPTION
with ws281x becoming a full python library, the module name changed from neopixel to rpi_ws281x